### PR TITLE
Using FileType in addition to extensions

### DIFF
--- a/plugin/hl-var.vim
+++ b/plugin/hl-var.vim
@@ -81,6 +81,8 @@ endfunction
 if (!exists("g:hlvarnoauto") || g:hlvarnoauto == 1)
     augroup HighlightVar
         autocmd!
+        au FileType perl :au CursorMoved  * call <sid>vawa()
+        au FileType perl :au CursorMovedi * call <sid>vawa()
         au CursorHold  *.pl call <sid>hlvar()
         au CursorHoldi *.pl call <sid>hlvar()
         au CursorHold  *.pm call <sid>hlvar()


### PR DESCRIPTION
Deal with the cases when file type is set but the extensions aren't known. Useful for people who have Mojolicious templates setup as "perl" and "html", or just having command line programs that don't have extensions relying on shebang.
